### PR TITLE
DM-37356: Added RB scores to cutout visualization

### DIFF
--- a/python/lsst/analysis/ap/zooniverseCutouts.py
+++ b/python/lsst/analysis/ap/zooniverseCutouts.py
@@ -473,6 +473,11 @@ def _annotate_image(fig, source, flags):
     if any(flags[flags_shape]):
         fig.text(0.87, 0.83, "SHAPE", color="red", fontweight="bold")
 
+    # rb score
+    fig.text(0.73, 0.79, f"RB:{source['spuriousness']:.03f}",
+             color="red" if source['spuriousness'] < 0.5 else "green",
+             fontweight="bold")
+
     fig.text(0.0, 0.79, "total (nJy):", color=flag_color if any(flags[flags_forced]) else text_color)
     fig.text(0.25, 0.79, f"{source['totFlux']:8.1f}", horizontalalignment='right')
     fig.text(0.252, 0.79, "+/-", color=text_color)

--- a/python/lsst/analysis/ap/zooniverseCutouts.py
+++ b/python/lsst/analysis/ap/zooniverseCutouts.py
@@ -474,9 +474,10 @@ def _annotate_image(fig, source, flags):
         fig.text(0.87, 0.83, "SHAPE", color="red", fontweight="bold")
 
     # rb score
-    fig.text(0.73, 0.79, f"RB:{source['spuriousness']:.03f}",
-             color="red" if source['spuriousness'] < 0.5 else "green",
-             fontweight="bold")
+    if np.isfinite(source['spuriousness']):
+        fig.text(0.73, 0.79, f"RB:{source['spuriousness']:.03f}",
+                 color='#e41a1c' if source['spuriousness'] < 0.5 else '#4daf4a',
+                 fontweight="bold")
 
     fig.text(0.0, 0.79, "total (nJy):", color=flag_color if any(flags[flags_forced]) else text_color)
     fig.text(0.25, 0.79, f"{source['totFlux']:8.1f}", horizontalalignment='right')

--- a/tests/test_zooniverseCutouts.py
+++ b/tests/test_zooniverseCutouts.py
@@ -61,6 +61,7 @@ DATA = pd.DataFrame(
         "isDipole": [True, False],
         # all flags vs. no flags
         "flags": [~0, 0],
+        "spuriousness": [0, 1.0],
     }
 )
 


### PR DESCRIPTION
They are expected to be in the apdb under the "spuriousness" column for now.