### PR TITLE
DM-39858: Integrate new CalibrateImageTask with AP cutouts code

### DIFF
--- a/python/lsst/analysis/ap/plotImageSubtractionCutouts.py
+++ b/python/lsst/analysis/ap/plotImageSubtractionCutouts.py
@@ -76,6 +76,11 @@ class PlotImageSubtractionCutoutsConfig(pexConfig.Config):
         dtype=str,
         default="deepDiff",
     )
+    science_image_type = pexConfig.Field(
+        doc="Dataset type of science image to use for cutouts.",
+        dtype=str,
+        default="calexp",
+    )
     add_metadata = pexConfig.Field(
         doc="Annotate the cutouts with catalog metadata, including coordinates, fluxes, flags, etc.",
         dtype=bool,
@@ -254,7 +259,7 @@ class PlotImageSubtractionCutoutsTask(lsst.pipe.base.Task):
             lru_cache above.
             """
             dataId = {'instrument': instrument, 'detector': detector, 'visit': visit}
-            return (butler.get('calexp', dataId),
+            return (butler.get(self.config.science_image_type, dataId),
                     butler.get(f'{self.config.diff_image_type}_templateExp', dataId),
                     butler.get(f'{self.config.diff_image_type}_differenceExp', dataId))
 


### PR DESCRIPTION
~WARNING: do not merge this PR as-is: I cherry-picked in my fixes from DM-39503 so that I could run with metadata outputs. This PR should only review and merge the science_image_type commit.~

Fixed by removing the cherry-picked DM-39503 commit: ready to merge.