### PR TITLE
DM-38528: Add min sources cut when loading objects

### DIFF
--- a/python/lsst/analysis/ap/apdb.py
+++ b/python/lsst/analysis/ap/apdb.py
@@ -233,16 +233,19 @@ class DbQuery(abc.ABC):
             result = pd.read_sql_query(query, connection)
         return result.iloc[0]
 
-    def load_objects(self, limit=100000, latest=True):
+    def load_objects(self, limit=100000, latest=True, min_sources=None):
         """Load all diaObjects.
 
         Parameters
         ----------
         limit : `int`
             Maximum number of rows to return.
-        latest : `bool`
+        latest : `bool`, optional
             Only load diaObjects where validityEnd is None.
             These are the most-recently updated diaObjects.
+        min_sources : `int`, optional
+            Restrict to diaObjects that have at least this many sources
+            (nDiaSources > min_sources).
 
         Returns
         -------
@@ -252,6 +255,8 @@ class DbQuery(abc.ABC):
         table = self._tables["DiaObject"]
         if latest:
             query = table.select().where(table.columns["validityEnd"] == None)  # noqa: E711
+        if min_sources is not None:
+            query = query.where(table.columns["nDiaSources"] > min_sources)  # noqa: E711
         query = query.order_by(table.columns["diaObjectId"])
         if limit is not None:
             query = query.limit(limit)

--- a/tests/test_apdb.py
+++ b/tests/test_apdb.py
@@ -93,6 +93,11 @@ class TestApdbSqlite(lsst.utils.tests.TestCase):
         result = self.apdb.load_objects(limit=2)
         self.assertEqual(len(result), 2)
 
+        # TODO DM-39503: No objects here have more than 1 source: once we have
+        # a larger test APDB, implement this check.
+        # result = self.apdb.load_objects(min_sources=2)
+        # self.assertEqual(len(result), SOMETHING)
+
     def test_load_forced_sources(self):
         result = self.apdb.load_forced_sources(limit=None)
         self.assertEqual(len(result), 15)


### PR DESCRIPTION
Made this change to ApdbQuery while chatting with Erin. It looks like this is one of the most common raw SQL DiaObject queries in notebook analysis work; this lets us get rid of that raw SQL.